### PR TITLE
Reduced use of comments for content hints

### DIFF
--- a/content-templates/default-index.yml
+++ b/content-templates/default-index.yml
@@ -1,33 +1,33 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}} # stub from prefix + module folder name
+uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: {{patternType}} # stub based on user selection: standard | introduction | choose | custom
-  title: "TODO" # user input: module title for browser tab and search results
-  description: "TODO" # user input: a description for site search and SEO
-  ms.date: {{msDate}} # stub with today's date
-  author: {{githubUsername}} # stub with GitHub ID from user settings
-  ms.author: {{msUser}} # stub with Microsoft alias from user settings
-  ms.topic: interactive-tutorial # do we need ms.topic?
-title: {{moduleTitle}} # stubbed from user input in VS Code (https://review.docs.microsoft.com/help/learn/id-guidance-title?branch=master)
-summary: "TODO" # user input: introductory summary (https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=master)
-abstract: | # user input: learning objectives (https://review.docs.microsoft.com/help/learn/id-guidance-learning-objectives?branch=master)
+  moduleType: {{patternType}}
+  title: {{moduleTitle}}
+  description: "TODO: this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: interactive-tutorial
+title: {{moduleTitle}}
+summary: "TODO: 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=master"
+abstract: |
   By the end of this module, you'll be able to: 
-    - # objective 1
-    - # objective 2
-    - # objective 3 (if needed)
-prerequisites: | # user input: prerequisites (https://review.docs.microsoft.com/help/learn/id-guidance-prerequisites?branch=master)
-  - # prerequisite 1
-  - # prerequisite 2
-  - # prerequisite 3
+    - "TODO learning objective 1"
+    - "TODO learning objective 2"
+    - "TODO learning objective 3 (if needed; see https://review.docs.microsoft.com/help/learn/id-guidance-learning-objectives?branch=master)"
+prerequisites: |
+  - "TODO prerequisite 1"
+  - "TODO prerequisite 2"
+  - "TODO prerequisite 3 (if needed; see https://review.docs.microsoft.com/help/learn/id-guidance-prerequisites?branch=master"
 iconUrl: /learn/achievements/generic-badge.svg
-levels: # user input: add levels from level taxonomy (https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#level)
+levels: # see level taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#level
   - # level
-roles: # user input: add roles from role taxonomy (https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#role)
+roles: # see role taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#role
   - # role 1
   - # role 2
-products: # stub default from user settings; user input: add product from product taxonomy (https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#product)
+products: # see product taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#product
   {{products}}
-units: # stub based on prefix, module folder, and unit names
+units:
   {{units}}
-badge: # stub based on prefix and module folder
+badge:
   uid: {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/default-index.yml
+++ b/content-templates/default-index.yml
@@ -8,6 +8,7 @@ metadata:
   author: {{githubUsername}}
   ms.author: {{msUser}}
   ms.topic: interactive-tutorial
+  ms.prod: learning-azure # Edit as appropriate for your portfolio area
 title: {{moduleTitle}}
 summary: "TODO: 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=master"
 abstract: |

--- a/content-templates/default-index.yml
+++ b/content-templates/default-index.yml
@@ -21,10 +21,9 @@ prerequisites: |
   - "TODO prerequisite 3 (if needed; see https://review.docs.microsoft.com/help/learn/id-guidance-prerequisites?branch=master"
 iconUrl: /learn/achievements/generic-badge.svg
 levels: # see level taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#level
-  - # level
+  - beginner
 roles: # see role taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#role
-  - # role 1
-  - # role 2
+  - developer
 products: # see product taxonomy https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=master#product
   {{products}}
 units:

--- a/content-templates/default-knowledge-check-unit.yml
+++ b/content-templates/default-knowledge-check-unit.yml
@@ -1,16 +1,15 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}} # stub from prefix + module folder name + default unit name 
-title: Knowledge check ### Do not edit: use "Knowledge check" as the title; also, don't add another title in the quiz element or an associated markdown page (if such a markdown page exists which is rare)
+uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+title: Knowledge check
 metadata:
   unitType: knowledge_check
-  title: "TODO" # user input: module title for browser tab and search results
-  description: "TODO" # user input: a description for site search and SEO
-  ms.date: {{msDate}} # stub with today's date
-  author: {{githubUsername}} # stub with GitHub ID from user settings
-  ms.author: {{msUser}} # stub with Microsoft alias from user settings
+  title: Knowledge check
+  description: "TODO: this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
   ms.topic: interactive-tutorial
-  ms.prod: "TODO"
-durationInMinutes: 1 # user input: the estimate time to complete the unit
+durationInMinutes: 1
 ###########################################################################
 ###
 ### General guidance (https://review.docs.microsoft.com/learn-docs/docs/id-guidance-knowledge-check) 

--- a/content-templates/default-knowledge-check-unit.yml
+++ b/content-templates/default-knowledge-check-unit.yml
@@ -9,6 +9,7 @@ metadata:
   author: {{githubUsername}}
   ms.author: {{msUser}}
   ms.topic: interactive-tutorial
+  ms.prod: learning-azure # Edit as appropriate for your portfolio area
 durationInMinutes: 1
 ###########################################################################
 ###

--- a/content-templates/default-learning-content-unit.md
+++ b/content-templates/default-learning-content-unit.md
@@ -50,7 +50,7 @@ TODO: add a visual element
     [Learning-unit structural guidance](https://review.docs.microsoft.com/learn-docs/docs/id-guidance-structure-learning-content?branch=master)
 -->
 
-<!-- Pattern for simple topic -->
+<!-- Pattern for simple chunks (repeat as needed) -->
 ## H2 heading
 Strong lead sentence; remainder of paragraph.
 Paragraph (optional)
@@ -58,7 +58,7 @@ Visual (image, table, list, code sample, blockquote)
 Paragraph (optional)
 Paragraph (optional)
 
-<!-- Pattern for complex topic -->
+<!-- Pattern for complex chunks (repeat as needed) -->
 ## H2 heading
 Strong lead sentence; remainder of paragraph.
 Visual (image, table, list)

--- a/content-templates/default-unit.yml
+++ b/content-templates/default-unit.yml
@@ -1,14 +1,14 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}} # stub from prefix + module folder name + default unit name 
-title: {{unitName}} # stub from default unit name
+uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+title: {{unitName}}
 metadata:
-  unitType: {{patternType}} # stub based on selected scaffold: introduction | learning_content | exercise | summary
-  title: "TODO" # user input: module title for browser tab and search results
-  description: "TODO" # user input: a description for site search and SEO
-  ms.date: {{msDate}} # stub with today's date
-  author: {{githubUsername}} # stub with GitHub ID from user settings
-  ms.author: {{msUser}} # stub with Microsoft alias from user settings
-  ms.topic: interactive-tutorial # do we need ms.topic?
-durationInMinutes: 1 # user input: the estimate time to complete the unit
+  unitType: {{patternType}}
+  title: {{unitName}}
+  description: "TODO: this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: interactive-tutorial
+durationInMinutes: 1
 content: |
   [!include[](includes/{{unitName}}.md)]

--- a/content-templates/default-unit.yml
+++ b/content-templates/default-unit.yml
@@ -9,6 +9,7 @@ metadata:
   author: {{githubUsername}}
   ms.author: {{msUser}}
   ms.topic: interactive-tutorial
+  ms.prod: learning-azure # Edit as appropriate for your portfolio area
 durationInMinutes: 1
 content: |
   [!include[](includes/{{unitName}}.md)]

--- a/content-templates/introduction-to-product/2-what-is-it.md
+++ b/content-templates/introduction-to-product/2-what-is-it.md
@@ -101,7 +101,7 @@ TODO: Add your visual element
     [Learning-unit structural guidance](https://review.docs.microsoft.com/learn-docs/docs/id-guidance-structure-learning-content?branch=master)
 -->
 
-<!-- Pattern for simple topic -->
+<!-- Pattern for simple chunks (repeat as needed) -->
 ## H2 heading
 Strong lead sentence; remainder of paragraph.
 Paragraph (optional)
@@ -109,7 +109,7 @@ Visual (image, table, list, code sample, blockquote)
 Paragraph (optional)
 Paragraph (optional)
 
-<!-- Pattern for complex topic -->
+<!-- Pattern for complex chunks (repeat as needed) -->
 ## H2 heading
 Strong lead sentence; remainder of paragraph.
 Visual (image, table, list, code sample, blockquote)

--- a/content-templates/introduction-to-product/5-knowledge-check.yml
+++ b/content-templates/introduction-to-product/5-knowledge-check.yml
@@ -1,15 +1,15 @@
 ### YamlMime:ModuleUnit
-uid: #{{learnRepo}}.{{moduleName}}.{{unitName}} # stub from prefix + module folder name + default unit name 
-title: Knowledge check ### Do not edit: use "Knowledge check" as the title; also, don't add another title in the quiz element or an associated markdown page (if such a markdown page exists which is rare)
+uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+title: Knowledge check
 metadata:
   unitType: knowledge_check
-  title: "TODO" # user input: module title for browser tab and search results
-  description: "TODO" # user input: a description for site search and SEO
-  ms.date: {{msDate}} # stub with today's date
-  author: {{githubUsername}} # stub with GitHub ID from user settings
-  ms.author: {{msUser}} # stub with Microsoft alias from user settings
-  ms.topic: interactive-tutorial # do we need ms.topic?
-durationInMinutes: 1 # user input: the estimate time to complete the unit
+  title: Knowledge check
+  description: "TODO: this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: interactive-tutorial
+durationInMinutes: 1
 ###########################################################################
 ###
 ### General guidance (https://review.docs.microsoft.com/learn-docs/docs/id-guidance-knowledge-check) 

--- a/content-templates/introduction-to-product/5-knowledge-check.yml
+++ b/content-templates/introduction-to-product/5-knowledge-check.yml
@@ -9,6 +9,7 @@ metadata:
   author: {{githubUsername}}
   ms.author: {{msUser}}
   ms.topic: interactive-tutorial
+  ms.prod: learning-azure # Edit as appropriate for your portfolio area
 durationInMinutes: 1
 ###########################################################################
 ###

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -107,8 +107,7 @@ levels:
 ### Use exact value(s) from the role taxonomy (https://review.docs.microsoft.com/en-us/help/contribute/metadata-taxonomies?branch=master#role)
 ###
 roles:
-  - # role 1
-  - # role 2
+  - developer
 ###########################################################################
 ###
 ### Specify the covered product.

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}} # Do not edit: uid must be globally unique
+uid: {{learnRepo}}.{{moduleName}}
 metadata:
   moduleType: introduction        # Do not edit: type must be 'introduction'
   title: {{moduleTitle}}          # Do not edit: title must be "Introduction to (product)"

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -8,6 +8,7 @@ metadata:
   author: {{githubUsername}}      # GitHub ID of the Microsoft employee either authoring or project-managing this content
   ms.author: {{msUser}}           # Alias     of the Microsoft employee either authoring or project-managing this content
   ms.topic: interactive-tutorial  # Do not edit: value must be "interactive-tutorial"
+  ms.prod: learning-azure         # Edit as appropriate for your portfolio area
 ###########################################################################
 ###
 ### Do not edit: title must be "Introduction to (product)"


### PR DESCRIPTION
- Multiple places / multiple files: moved content hints from YAML/markdown comments into "TODO: hint" style text (based on user feedback - this reduces their work to delete comments after adding their real content).

- Removed comments that described how the scaffold tooling generated default values, e.g.   "ms.date: {{msDate}} # stub with today's date"

- Added "beginner" as the default level in the default-index.yml file

- Added "developer" as the default role in the default-index.yml file
