### PR TITLE
Remove deprecated metadata: unitType & moduleType

### DIFF
--- a/content-templates/build-your-first-using-product/index.yml
+++ b/content-templates/build-your-first-using-product/index.yml
@@ -1,7 +1,6 @@
 ### YamlMime:Module
 uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: build-your-first-using-product # Do not edit: type must be 'build-your-first-using-product'
   title: {{moduleTitle}}                     # Title must be "(verb) your first (thing) by using (product)"
   description: "TODO"                        # Copy your 'apply' Learning Objective here (see below)
   ms.date: {{msDate}}                        # Date of commit to GitHub (do not use target publication date, cannot be in the future)

--- a/content-templates/challenge-project/index.yml
+++ b/content-templates/challenge-project/index.yml
@@ -1,7 +1,6 @@
 ### YamlMime:Module
 uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: {{patternType}}
   title: {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/challenge-project/prepare.yml
+++ b/content-templates/challenge-project/prepare.yml
@@ -2,7 +2,6 @@
 uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Prepare
 metadata:
-  unitType: {{patternType}}
   title: Prepare
   description: "Project specification and setup requirements."
   ms.date: {{msDate}}

--- a/content-templates/default-units/index.yml
+++ b/content-templates/default-units/index.yml
@@ -1,7 +1,6 @@
 ### YamlMime:Module
 uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: {{patternType}}
   title: {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/default-units/knowledge-check-unit.yml
+++ b/content-templates/default-units/knowledge-check-unit.yml
@@ -2,7 +2,6 @@
 uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Knowledge check
 metadata:
-  unitType: knowledge_check
   title: Knowledge check
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/default-units/unit.yml
+++ b/content-templates/default-units/unit.yml
@@ -2,7 +2,6 @@
 uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: {{unitName}}
 metadata:
-  unitType: {{patternType}}
   title: {{unitName}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/guided-project/index.yml
+++ b/content-templates/guided-project/index.yml
@@ -1,7 +1,6 @@
 ### YamlMime:Module
 uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: {{patternType}}
   title: {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/guided-project/prepare.yml
+++ b/content-templates/guided-project/prepare.yml
@@ -2,7 +2,6 @@
 uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Prepare
 metadata:
-  unitType: {{patternType}}
   title: Prepare
   description: "Project overview and setup requirements."
   ms.date: {{msDate}}

--- a/content-templates/introduction-to-product/5-knowledge-check.yml
+++ b/content-templates/introduction-to-product/5-knowledge-check.yml
@@ -2,7 +2,6 @@
 uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Knowledge check
 metadata:
-  unitType: knowledge_check
   title: Knowledge check
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
   ms.date: {{msDate}}

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -1,7 +1,6 @@
 ### YamlMime:Module
 uid: {{learnRepo}}.{{moduleName}}
 metadata:
-  moduleType: introduction        # Do not edit: type must be 'introduction'
   title: {{moduleTitle}}          # Do not edit: title must be "Introduction to (product)"
   description: "TODO"             # Copy your 'evaluate' Learning Objective here (see below)
   ms.date: {{msDate}}             # Date of commit to GitHub (do not use target publication date, cannot be in the future)


### PR DESCRIPTION
The metadata team indicated we are moving away from adding metadata so we need to remove these from the templates (they were really a prototype anyway and not fully implemented).

@jamarw 

@meganbradley 