### PR TITLE
Fixed issue with learn-scaffolding extension

### DIFF
--- a/content-templates/build-your-first-using-product/index.yml
+++ b/content-templates/build-your-first-using-product/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}            # Title must be "(verb) your first (thing) by using (product)"
+  title: |
+    {{moduleTitle}}            # Title must be "(verb) your first (thing) by using (product)"
   description: "TODO"               # Copy your 'apply' Learning Objective here (see below)
   ms.date: {{msDate}}               # Date of commit to GitHub (do not use target publication date, cannot be in the future)
   author: {{githubUsername}}        # GitHub ID of the Microsoft employee either authoring or project-managing this content
@@ -18,7 +20,8 @@ metadata:
 ###
 ### Title must be "(verb) your first (thing) by using (product)"
 ###
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 ###########################################################################
 ###
 ### Summary
@@ -132,4 +135,5 @@ units:
 ### TODO verify your badge
 ###
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/challenge-project/index.yml
+++ b/content-templates/challenge-project/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}
+  title: |
+    {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -20,7 +22,8 @@ metadata:
   ms.prod: TODO
   ms.service: TODO
 
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 
 summary: |
   TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title, include the note below; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main
@@ -48,4 +51,5 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/challenge-project/prepare.yml
+++ b/content-templates/challenge-project/prepare.yml
@@ -1,5 +1,6 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Prepare
 metadata:
   title: Prepare

--- a/content-templates/choose-best-product/index.yml
+++ b/content-templates/choose-best-product/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}
+  title: |
+    {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -19,7 +21,8 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 summary: "TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main"
 abstract: |
   By the end of this module, you'll be able to: 
@@ -42,4 +45,5 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/default-units/knowledge-check-unit.yml
+++ b/content-templates/default-units/knowledge-check-unit.yml
@@ -1,5 +1,6 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Knowledge check
 metadata:
   title: Knowledge check

--- a/content-templates/default-units/unit.yml
+++ b/content-templates/default-units/unit.yml
@@ -1,8 +1,11 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
-title: {{unitName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}.{{unitName}}
+title: |
+  {{unitName}}
 metadata:
-  title: {{unitName}}
+  title: |
+    {{unitName}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}

--- a/content-templates/guided-project/index.yml
+++ b/content-templates/guided-project/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}
+  title: |
+    {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -19,7 +21,8 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 
 summary: |
   TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title, include the note below; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main
@@ -47,4 +50,5 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/guided-project/prepare.yml
+++ b/content-templates/guided-project/prepare.yml
@@ -1,5 +1,6 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Prepare
 metadata:
   title: Prepare

--- a/content-templates/introduction-to-product/5-knowledge-check.yml
+++ b/content-templates/introduction-to-product/5-knowledge-check.yml
@@ -1,5 +1,6 @@
 ### YamlMime:ModuleUnit
-uid: {{learnRepo}}.{{moduleName}}.{{unitName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}.{{unitName}}
 title: Knowledge check
 metadata:
   title: Knowledge check

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}            # Do not edit: title must be "Introduction to (product)"
+  title: |
+    {{moduleTitle}}            # Do not edit: title must be "Introduction to (product)"
   description: "TODO"               # Copy your 'evaluate' Learning Objective here (see below)
   ms.date: {{msDate}}               # Date of commit to GitHub (do not use target publication date, cannot be in the future)
   author: {{githubUsername}}        # GitHub ID of the Microsoft employee either authoring or project-managing this content
@@ -23,7 +25,8 @@ metadata:
 ###
 ### Do not edit: title must be "Introduction to (product)"
 ###
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 ###########################################################################
 ###
 ### Summary
@@ -144,4 +147,5 @@ units: # stub based on prefix, module folder, and unit names
 ### TODO verify your badge
 ###
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/standard-task-based/index.yml
+++ b/content-templates/standard-task-based/index.yml
@@ -1,7 +1,9 @@
 ### YamlMime:Module
-uid: {{learnRepo}}.{{moduleName}}
+uid: |
+  {{learnRepo}}.{{moduleName}}
 metadata:
-  title: {{moduleTitle}}
+  title: |
+    {{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -19,7 +21,8 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: {{moduleTitle}}
+title: |
+  {{moduleTitle}}
 summary: "TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main"
 abstract: |
   By the end of this module, you'll be able to: 
@@ -42,4 +45,5 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: {{learnRepo}}.{{moduleName}}.badge
+  uid: |
+    {{learnRepo}}.{{moduleName}}.badge


### PR DESCRIPTION
Yaml was not able to be parsed because the values for uid: {{learnRepo}}.{{moduleName}} we not being evaluated as strings. Simply adding a | before the string allowed the schema to validate correctly.

- Changed all places where {{learnRepo}}.{{moduleName}} variable names were being used. They now start with | to make sure schema knows they are a string instead of object.

This should not have any affect on the values replaced by the extensions and will not display the | when using the extension. 