### PR TITLE
Fixed pipes in templates to string literal with $

### DIFF
--- a/content-templates/build-your-first-using-product/index.yml
+++ b/content-templates/build-your-first-using-product/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}            # Title must be "(verb) your first (thing) by using (product)"
+  title: ${{moduleTitle}}            # Title must be "(verb) your first (thing) by using (product)"
   description: "TODO"               # Copy your 'apply' Learning Objective here (see below)
   ms.date: {{msDate}}               # Date of commit to GitHub (do not use target publication date, cannot be in the future)
   author: {{githubUsername}}        # GitHub ID of the Microsoft employee either authoring or project-managing this content
@@ -19,8 +18,7 @@ metadata:
 ###
 ### Title must be "(verb) your first (thing) by using (product)"
 ###
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 ###########################################################################
 ###
 ### Summary
@@ -134,5 +132,4 @@ units:
 ### TODO verify your badge
 ###
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/challenge-project/index.yml
+++ b/content-templates/challenge-project/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}
+  title: ${{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -21,8 +20,7 @@ metadata:
   ms.prod: TODO
   ms.service: TODO
 
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 
 summary: |
   TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title, include the note below; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main
@@ -50,5 +48,4 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/choose-best-product/index.yml
+++ b/content-templates/choose-best-product/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}
+  title: ${{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -20,8 +19,7 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 summary: "TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main"
 abstract: |
   By the end of this module, you'll be able to: 
@@ -44,5 +42,4 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/default-units/unit.yml
+++ b/content-templates/default-units/unit.yml
@@ -1,10 +1,8 @@
 ### YamlMime:ModuleUnit
 uid: ${{learnRepo}}.{{moduleName}}.{{unitName}}
-title: |
-  {{unitName}}
+title: ${{unitName}}
 metadata:
-  title: |
-    {{unitName}}
+  title: ${{unitName}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}

--- a/content-templates/guided-project/index.yml
+++ b/content-templates/guided-project/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}
+  title: ${{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -20,8 +19,7 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 
 summary: |
   TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title, include the note below; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main
@@ -49,5 +47,4 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/introduction-to-product/index.yml
+++ b/content-templates/introduction-to-product/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}            # Do not edit: title must be "Introduction to (product)"
+  title: ${{moduleTitle}}            # Do not edit: title must be "Introduction to (product)"
   description: "TODO"               # Copy your 'evaluate' Learning Objective here (see below)
   ms.date: {{msDate}}               # Date of commit to GitHub (do not use target publication date, cannot be in the future)
   author: {{githubUsername}}        # GitHub ID of the Microsoft employee either authoring or project-managing this content
@@ -24,8 +23,7 @@ metadata:
 ###
 ### Do not edit: title must be "Introduction to (product)"
 ###
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 ###########################################################################
 ###
 ### Summary
@@ -146,5 +144,4 @@ units: # stub based on prefix, module folder, and unit names
 ### TODO verify your badge
 ###
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/standard-task-based/index.yml
+++ b/content-templates/standard-task-based/index.yml
@@ -1,8 +1,7 @@
 ### YamlMime:Module
 uid: ${{learnRepo}}.{{moduleName}}
 metadata:
-  title: |
-    {{moduleTitle}}
+  title: ${{moduleTitle}}
   description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the module; include relevant search keywords."
   ms.date: {{msDate}}
   author: {{githubUsername}}
@@ -20,8 +19,7 @@ metadata:
 ### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
   ms.prod: TODO
   ms.service: TODO
-title: |
-  {{moduleTitle}}
+title: ${{moduleTitle}}
 summary: "TODO 2 sentences, 20-35 words, don't teach or motivate, avoid using 'learn', don't duplicate the title; see https://review.docs.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main"
 abstract: |
   By the end of this module, you'll be able to: 
@@ -44,5 +42,4 @@ subjects: # see subject taxonomy https://review.docs.microsoft.com/help/contribu
 units:
   {{units}}
 badge:
-  uid: |
-    {{learnRepo}}.{{moduleName}}.badge
+  uid: ${{learnRepo}}.{{moduleName}}.badge


### PR DESCRIPTION
Removed pipe | from title and uid for badge and replaced with $ for string literal replace. This should fix this bug: https://dev.azure.com/ceapex/Engineering/_backlogs/backlog/Authoring/Backlog%20items/?workitem=930467