### PR TITLE
Add templates for Standard concept-based pattern

### DIFF
--- a/content-templates/default-units/knowledge-check-unit.yml
+++ b/content-templates/default-units/knowledge-check-unit.yml
@@ -7,23 +7,24 @@ metadata:
   ms.date: {{msDate}}
   author: {{githubUsername}}
   ms.author: {{msUser}}
-  ms.topic: interactive-tutorial
+  ms.topic: unit
 ###########################################################################
 ###
-### If your content is related to a product or service, apply one value from the either the ms.prod allowlist
-### or the ms.service allowlist. You can’t use both ms.prod and ms.service.
+### If your content is related to a product or service, apply one value from
+### the ms.service allowlist.
 ###
-### If your content isn't about a product or service, you can omit both ms.prod and ms.service.
+### If your content isn't about a product or service, you can omit the ms.service field.
 ###
-### The list of approved ms.prod values is here: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msprod
-### The list of approved ms.service values is here: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msservice
-### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
-  ms.prod: TODO
+### For the list of approved ms.service values, go to
+### https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msservice.
+###
+### To request new values, go to
+### https://review.learn.microsoft.com/help/platform/metadata-reporting-taxonomy-requests?branch=main.
   ms.service: TODO
 durationInMinutes: 1
 ###########################################################################
 ###
-### General guidance (https://review.docs.microsoft.com/learn-docs/docs/id-guidance-knowledge-check) 
+### General guidance (https://review.learn.microsoft.com/help/learn/id-guidance-knowledge-check?branch=main) 
 ###  - Questions are complete sentences ending with a question mark 
 ###  - No true/false questions 
 ###  - 3 answers per question 

--- a/content-templates/default-units/summary.md
+++ b/content-templates/default-units/summary.md
@@ -6,7 +6,7 @@
 
     Example: "You are writing the instruction manual for a new model fire extinguisher. The instructions must be quickly read and understood by a wide variety of people."
 
-    [Summary unit guidance](https://review.docs.microsoft.com/learn-docs/docs/id-guidance-module-summary-unit?branch=main)
+    [Summary unit guidance](https://review.learn.microsoft.com/help/learn/id-guidance-module-summary-unit?branch=main)
 -->
 TODO: restate the scenario problem
 

--- a/content-templates/default-units/unit.yml
+++ b/content-templates/default-units/unit.yml
@@ -7,18 +7,19 @@ metadata:
   ms.date: {{msDate}}
   author: {{githubUsername}}
   ms.author: {{msUser}}
-  ms.topic: interactive-tutorial
+  ms.topic: unit
 ###########################################################################
 ###
-### If your content is related to a product or service, apply one value from the either the ms.prod allowlist
-### or the ms.service allowlist. You can’t use both ms.prod and ms.service.
+### If your content is related to a product or service, apply one value from
+### the ms.service allowlist.
 ###
-### If your content isn't about a product or service, you can omit both ms.prod and ms.service.
+### If your content isn't about a product or service, you can omit the ms.service field.
 ###
-### The list of approved ms.prod values is here: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msprod
-### The list of approved ms.service values is here: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msservice
-### If you need to request new values, follow the process here: https://review.learn.microsoft.com/en-us/help/platform/metadata-allowlist-requests?branch=main
-  ms.prod: TODO
+### For the list of approved ms.service values, go to
+### https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msservice.
+###
+### To request new values, go to
+### https://review.learn.microsoft.com/help/platform/metadata-reporting-taxonomy-requests?branch=main.
   ms.service: TODO
 durationInMinutes: 1
 content: |

--- a/content-templates/standard-concept-based/exercise.md
+++ b/content-templates/standard-concept-based/exercise.md
@@ -1,0 +1,116 @@
+<!-- 1. Topic sentences ----------------------------------------------------------------------------------
+
+    Goal: Remind the user of the core concepts from the preceding concept unit without mentioning the
+          details of the exercise or the scenario.
+
+    Heading: None
+
+    Example: "In sorted data, elements are ordered by name, size, or another characteristic that a
+             comparison operator can work with."
+
+    Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-introductions#exercise-unit-introduction`
+-->
+TODO: Add your topic sentences.
+
+<!-- 2. Scenario subtask ---------------------------------------------------------------------------------
+
+    Goal: Describe the part of the scenario that the exercise covers.
+
+    Heading: Optional
+
+    Position: Position this content according to its length. Either place it in a separate paragraph, or
+              combine it with the previous section into a single paragraph.
+
+    Example: "In the sales company scenario, the manager needs to track sales volume. Sorting the sales
+             data can make it easy to spot low-performing areas."
+
+    Recommended: Add an image that summarizes the entire scenario and highlights the area that this
+                 exercise implements.
+-->
+TODO: Add your scenario subtask.
+TODO: Optionally, add your scenario image.
+
+<!-- 3. Task performed in the exercise -------------------------------------------------------------------
+
+    Goal: State concisely what the learner implements in the exercise. Describe the end state after
+          completion.
+
+    Heading: Optional
+
+    Position: Position this content according to its length. Either place it in a separate paragraph, or
+              combine it with the previous section into a single paragraph.
+
+    Example: "In this exercise, you sort data in a spreadsheet. Within a column, the lowest values move
+             to the top, and the greatest values move to the bottom."
+
+    Optional: Include an image that shows the end state.
+-->
+TODO: Describe the end state.
+TODO: Optionally, add an image.
+
+<!-- 4. Chunked steps ------------------------------------------------------------------------------------
+
+    Goal: List the steps the user takes to complete the exercise.
+
+    Structure: Break the steps into chunks, where each chunk has three parts:
+        1. A heading describing the goal of the chunk.
+        2. An introductory paragraph describing the goal of the chunk at a high level.
+        3. Numbered steps. If possible, use seven or fewer steps in each chunk.
+
+    Example:
+        "## Sort data by size
+
+        When you analyze data, you can order the data by size to quickly see the minimum and maximum
+        values.
+
+        1. In the spreadsheet, select all the data in the **Region** and **Sales volume** columns.
+        2. Select **Data** > **Sort**.
+        3. In the pop-up window, under **Column**, select **Sales volume**.
+        4. Under **Order**, select **Smallest to Largest**.
+        5. Examine the data in the **Sales volume** column. Note that the minimum value is at the top of
+           the column, and the maximum value is at the bottom."
+-->
+<!-- Pattern for chunks. Repeat as needed. -->
+## TODO: Add your chunk heading.
+TODO: Add your chunk introduction paragraph.
+
+1. TODO: Add the first step.
+1. TODO: Add the second step.
+1. ...
+1. TODO: Add the last step.
+
+<!-- 5. Validation ---------------------------------------------------------------------------------------
+
+    Goal: Enable the learner to evaluate whether they completed the exercise correctly.
+
+    Heading: "## Check your work"
+
+    Structure:
+        1. An introductory paragraph describing how the user validates their work at a high level
+        2. Numbered steps, if the user needs to perform multiple steps to verify success
+        3. An optional video of an expert performing the exact steps of the exercise
+
+    Example:
+        "## Check your work
+
+        The data is now sorted by sales volume. To verify that the data is ordered correctly, we'll look
+        at individual values in this column.
+
+        1. In the **Sales volume** column, check that the first value is less than the second value.
+        2. Move down one row, and check that the second value is less than the third value.
+        3. Continue moving down rows in the **Sales volume** column and checking that each value is less
+           than the one below it.
+        4. When you reach the last row and have verified that each value is less than the one below it,
+           the validation is complete."
+-->
+## Check your work
+TODO: Add your introduction paragraph.
+
+1. TODO: Add the first step.
+1. TODO: Add the second step.
+1. ...
+1. TODO: Add the last step.
+
+TODO: Optionally, add your exercise solution video.
+
+<!-- Don't include a unit summary, a lead-in sentence to the next unit, or references. -->

--- a/content-templates/standard-concept-based/index.yml
+++ b/content-templates/standard-concept-based/index.yml
@@ -1,0 +1,169 @@
+### YamlMime:Module
+uid: ${{learnRepo}}.{{moduleName}}
+metadata:
+  title: ${{moduleTitle}}
+  description: "TODO" # Describe the module in 120 to 165 characters. Include relevant search keywords.
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: module-concept
+###########################################################################
+###
+### ms.service value
+###
+### If your content is related to a product or service, apply one value from
+### the ms.service allowlist.
+###
+### If your content isn't about a product or service, you can omit the ms.service field.
+###
+### For the list of approved ms.service values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main`.
+###
+### To request new values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-reporting-taxonomy-requests?branch=main`.
+  ms.service: TODO
+title: ${{moduleTitle}}
+###########################################################################
+###
+### Introductory summary
+###
+### General guidelines:
+###   - Write two sentences.
+###   - Generally use 20-25 words but no more than 35.
+###   - Avoid "learn" and "in this module."
+###   - Don't repeat title phrases.
+###   - Don't teach.
+###
+### First sentence:
+###   - Describe why the concepts are important or how they're used.
+###   - Example 1: "Secure authentication and authorization are a cornerstone of
+###                protecting against cybersecurity threats."
+###   - Example 2: "Relational databases are used to track inventories, process
+###                e-commerce transactions, manage mission-critical customer
+###                information, and more."
+###
+### Second sentence:
+###   - Describe the concepts that the module covers.
+###   - Example 1: "Learn about common identity-based attacks, effective
+###                authentication methods, and common techniques to protect against
+###                unauthorized access."
+###   - Example 2: "We'll cover the core ideas underlying relational databases
+###                including tables, normalization, stored procedures, and the SQL
+###                query language."
+###
+### Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-introductory-summaries?branch=main`
+###
+summary: "TODO"
+###########################################################################
+###
+### Learning objectives
+###
+### Guidelines:
+###   - Base remember-level objectives on expressing that the user can recall
+###     definitions and facts:
+###     - Example 1: "Define feature scaling."
+###     - Example 2: "List key strategies for observing the overall health of the
+###                  system."
+###   - Base understand-level objectives on expressing that the user can explain a
+###     concept in their own words:
+###     - Example 1: "Describe how delivery plans allow multiple teams to plan,
+###                  schedule, and coordinate their work."
+###     - Example 2: "Explain the Dickerson hierarchy of reliability and the map it
+###                  provides for approaching reliability challenges."
+###   - Base apply-level objectives on expressing that the user can determine
+###     whether an example fits a definition:
+###     - Example 1: "Distinguish between different models to understand which one
+###                  to choose for what purpose."
+###     - Example 2: "Classify programs as sequential, concurrent, parallel, and
+###                  distributed."
+###
+### Notes:
+###   - The YAML field name is "abstract," but it contains your learning objectives.
+###   - Start each objective with an uppercase letter.
+###   - End each objective with a period.
+###
+### Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-learning-objectives?branch=main`
+###
+abstract: |
+  By the end of this module, you'll be able to:
+  - TODO
+  - TODO
+  - ...
+  - TODO
+###########################################################################
+###
+### Prerequisites
+###
+### General guidance:
+###   - List the skills learners need to have before starting this module.
+###   - Be specific. For example, use "Familiarity with programming concepts such as
+###     loops, conditionals, and variables," not "Familiarity with programming
+###     concepts."
+###   - Don't mention or link to other content that teaches the required prerequisite
+###     skills.
+###   - If needed, include software setup requirements with setup links.
+###
+### Example:
+###   Prerequisite 1: "Familiarity with programming concepts such as conditional
+###                   logic and loops"
+###   Prerequisite 2: "Basic knowledge of REST services and APIs"
+###
+### Detailed guidance: `https://review.docs.microsoft.com/help/learn/id-guidance-prerequisites`
+###
+prerequisites: |
+  - TODO
+  - TODO
+  - ...
+  - TODO
+###########################################################################
+###
+### Icon URL
+###
+### Guidance:
+###   - Enter the site-relative link of the module image that should appear on the
+###     module landing page.
+###   - Use the temporary generic badge "/training/achievements/generic-badge.svg"
+###     if your module badge isn't yet available.
+###
+### Detailed guidance: `https://review.learn.microsoft.com/help/learn/achievements-creation`
+###
+iconUrl: TODO
+###########################################################################
+###
+### Learning level
+###
+### Don't edit this value. Use a level of `beginner`.
+###
+levels:
+  - beginner
+###########################################################################
+###
+### Role list
+###
+### Specify the target roles. Use values from the taxonomy at
+### `https://review.learn.microsoft.com/help/platform/metadata-taxonomies`.
+###
+roles:
+  - TODO
+###########################################################################
+###
+### Product list
+###
+### List the main product or products that the module discusses. Use values
+### from the taxonomy at `https://review.learn.microsoft.com/help/platform/metadata-taxonomies`.
+###
+products:
+  {{products}}
+###########################################################################
+###
+### Subject list
+###
+### Specify the subject areas. Use values from the subject taxonomy at
+### `https://review.learn.microsoft.com/help/platform/metadata-taxonomies`.
+###
+subjects:
+  - TODO
+units:
+  {{units}}
+badge:
+  uid: ${{learnRepo}}.{{moduleName}}.badge

--- a/content-templates/standard-concept-based/introduction.md
+++ b/content-templates/standard-concept-based/introduction.md
@@ -1,0 +1,89 @@
+<!-- 1. Topic sentences ----------------------------------------------------------------------------------
+
+    Goal: Orient the learner to the area covered in this module.
+
+    Heading: None
+
+    Example: "Good cybersecurity relies on many factors to provide confidence and assurance that your data
+             is safe and being used as expected."
+
+    Recommended: Add a visual like an image, table, or list that supports the topic sentences.
+
+    Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-introductions?branch=main#module-introduction`
+-->
+TODO: Add your topic sentences.
+TODO: Optionally, add a visual element.
+
+<!-- 2. Motivation ---------------------------------------------------------------------------------------
+
+    Goal: Explain why the concepts that the module covers are important and how they're used. Consider
+          posing a question or describing a challenging situation.
+
+    Heading: None
+
+    Example: "In the early years of computing systems, every application stored data in its own unique
+             structure. When developers wanted to build applications to use that data, they had to know
+             a lot about the data structure to find the data they needed. These structures were
+             inefficient, hard to maintain, and hard to optimize for good application performance. The
+             relational database model was designed to solve the problem of multiple arbitrary data
+             structures. The relational model provides a standard way of representing and querying
+             data that can be used by any application."
+-->
+TODO: Add your motivation.
+
+<!-- 3. Scenario -----------------------------------------------------------------------------------------
+
+    Goal: Describe a real-world scenario that this module uses to illustrate concepts.
+
+    Heading: "## Example scenario"
+
+    Example: "Authentication and authorization are two key factors. Authentication provides the mechanism
+             for you to trust that someone is who they claim to be. When you've authenticated a user, you
+             need to decide what they're permitted to do. Authorization grants each user a specific level
+             of access to data and assets. Authentication is the key that opens the door, while
+             authorization decides where you can go and what you can see inside."
+
+    Recommended: Add a visual that illustrates the scenario.
+
+    Optional: Add a video that visualizes the scenario.
+
+    Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-scenarios?branch=main`
+ -->
+## Example scenario
+TODO: Add your scenario.
+TODO: Add a visual element.
+TODO: Optionally, add a scenario video.
+
+<!-- 4. Prose table of contents --------------------------------------------------------------------------
+
+    Goal: List the activities that the learner does in this module. The prose table of contents differs
+          from the title and the learning objectives. The title and the learning objectives are outcome-
+          focused. They describe the skills the learner acquires as a result of consuming this content.
+          In contrast, the prose table of contents states specifically what the learner **does** in order
+          to acquire those skills. The format can be either prose or a bulleted list. But a list yields
+          better results when transformed into other output types such as PowerPoint.
+
+    Heading: "## What will we be doing?"
+
+    Example: "In this module, we'll formally define several cybersecurity concepts like authentication
+             and authorization. Then we'll put the concepts into context by describing some common
+             authentication-based attacks. We'll also define some effective authorization security techniques."
+ -->
+## What will we be doing?
+TODO: State what the module covers.
+
+<!-- 5. Terminal learning objective ----------------------------------------------------------------------
+
+    Goal: Restate the module title as a complete sentence. You have more room here to convey the main goal
+          than in a space-limited title. Make it outcome-focused so it describes the main skills and
+          knowledge the learner acquires as a result of the training. Answer the question "What is the
+          foundational knowledge the user gains as a result of consuming this training?"
+
+    Heading: "## What is the main goal?"
+
+    Example: "By the end of the module, you'll have a comprehensive understanding of core cybersecurity concepts."
+ -->
+## What is the main goal?
+By the end of this session, you'll TODO: Add your terminal learning objective.
+
+<!-- Don't include any other content like learning objectives, prerequisites, a unit summary, a lead-in sentence to the next unit, or references. -->

--- a/content-templates/standard-concept-based/learning-content.md
+++ b/content-templates/standard-concept-based/learning-content.md
@@ -1,0 +1,84 @@
+<!-- 1. Topic sentences ----------------------------------------------------------------------------------
+
+    Goal: Briefly summarize the concepts that this unit teaches.
+
+    Heading: None
+
+    Example: "In addition to tables, a relational database can contain other structures that help to
+             optimize data organization, encapsulate programmatic actions, and improve the speed of access."
+
+    Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-introductions?branch=main#learning-unit-introduction`
+-->
+TODO: Add your topic sentences.
+
+<!-- 2. Scenario subtask ---------------------------------------------------------------------------------
+
+    Goal: Describe the part of the scenario that the content in this unit solves.
+
+    Heading: None
+
+    Position: Combine this content with the topic sentences into a single paragraph.
+
+    Example: "In the sales company scenario, we can use normalization to minimize duplication and enforce
+             integrity in the inventory and order data."
+-->
+TODO: Add your scenario subtask.
+
+<!-- 3. Prose table of contents --------------------------------------------------------------------------
+
+    Goal: State concisely what the unit covers.
+
+    Heading: None
+
+    Position: Combine this statement with the topic sentences and scenario subtask into a single paragraph.
+
+    Example: "In this unit, you'll learn about three of these structures in more detail: views, stored
+             procedures, and indexes."
+-->
+TODO: Write your prose table of contents.
+
+<!-- 4. Motivation ---------------------------------------------------------------------------------------
+
+    Goal: Provide motivation for learning the concepts in the unit.
+
+    Heading: None
+
+    Position: Position this content according to its length. Either place it in a separate paragraph, or
+              combine it with the previous section into a single paragraph.
+
+    Example: "Redundant data wastes disk space and creates maintenance problems. If data that exists in
+             more than one place must be changed, the data must be changed in the same way in all
+             locations. An address change is much easier to implement if that data is stored only in one
+             table and nowhere else in the database."
+-->
+TODO: Add your motivation.
+
+<!-- 5. Chunked content ----------------------------------------------------------------------------------
+
+    Goal: Provide all the information the learner needs to understand a concept.
+
+    Structure: Break the content into chunks, where each chunk has the following parts:
+        1. An H2 or H3 heading of <concept>
+        2. A transition from a previous concept if this chunk isn't the first one
+        3. A definition of the concept
+        4. Examples or counterexamples that illustrate the concept
+
+    Detailed guidance: `https://review.learn.microsoft.com/help/patterns/level4/id-guidance-standard-concept-based#mix-motivation-definition-and-examples-in-concept-units`
+-->
+## <first-concept>
+TODO: Add your first chunk's definition.
+TODO: Add your first chunk's examples.
+
+## <second-concept>
+TODO: Add your transition.
+TODO: Add your second chunk's definition.
+TODO: Add your second chunk's examples.
+
+...
+
+## <last-concept>
+TODO: Add your transition.
+TODO: Add your last chunk's definition.
+TODO: Add your last chunk's examples.
+
+<!-- Don't include a unit summary, a lead-in sentence to the next unit, or references. -->

--- a/content-templates/standard-concept-based/pretest.yml
+++ b/content-templates/standard-concept-based/pretest.yml
@@ -1,0 +1,101 @@
+### YamlMime:ModuleUnit
+uid: ${{learnRepo}}.{{moduleName}}.{{unitName}}
+title: Pretest
+metadata:
+  title: Pretest
+  description: TODO # Describe the unit in 120 to 165 characters. Include relevant search keywords.
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: unit
+###########################################################################
+###
+### ms.service value
+###
+### If your content is related to a product or service, apply one value from
+### the ms.service allowlist.
+###
+### If your content isn't about a product or service, you can omit the ms.service field.
+###
+### For the list of approved ms.service values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main`.
+###
+### To request new values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-reporting-taxonomy-requests?branch=main`
+  ms.service: TODO
+durationInMinutes: 1
+###########################################################################
+###
+### Questions and answers
+###
+### General guidance:
+###  - Make questions complete sentences that end with a question mark.
+###  - Don't use "not" or "except" in questions.
+###  - Provide three answers per question.
+###  - Make all answers about the same length.
+###  - List numeric answers in sorted order.
+###  - Don't use "true" or "false" as answer choices.
+###  - Don't use "All of the above" or "None of the above" as answer choices.
+###  - Don't use the second person ("you") in questions or answers.
+###  - Provide a meaningful explanation for correct and incorrect answers.
+###
+### Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-knowledge-check?branch=main`
+###########################################################################
+content: |
+quiz:
+  questions:
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"

--- a/content-templates/standard-concept-based/unit.yml
+++ b/content-templates/standard-concept-based/unit.yml
@@ -1,0 +1,80 @@
+### YamlMime:ModuleUnit
+uid: ${{learnRepo}}.{{moduleName}}.{{unitName}}
+title: ${{unitName}}
+metadata:
+  title: ${{unitName}}
+  description: "TODO this field is for search engine optimization and is not user-visible; use 2-3 complete, grammatically correct sentences to describe the unit; include relevant search keywords."
+  ms.date: {{msDate}}
+  author: {{githubUsername}}
+  ms.author: {{msUser}}
+  ms.topic: unit
+###########################################################################
+###
+### ms.service value
+###
+### If your content is related to a product or service, apply one value from
+### the ms.service allowlist.
+###
+### If your content isn't about a product or service, you can omit the ms.service field.
+###
+### For the list of approved ms.service values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main`.
+###
+### To request new values, go to
+### `https://review.learn.microsoft.com/help/platform/metadata-reporting-taxonomy-requests?branch=main`.
+  ms.service: TODO
+durationInMinutes: 1
+content: |
+  [!include[](includes/{{unitName}}.md)]
+###########################################################################
+###
+### Optional end-of-unit knowledge check
+###
+### General guidance:
+###  - Make questions complete sentences that end with a question mark.
+###  - Don't use "not" or "except" in questions.
+###  - Provide three answers per question.
+###  - Make all answers about the same length.
+###  - List numeric answers in sorted order.
+###  - Don't use "true" or "false" as answer choices.
+###  - Don't use "All of the above" or "None of the above" as answer choices.
+###  - Don't use the second person ("you") in questions or answers.
+###  - Provide a meaningful explanation for correct and incorrect answers.
+###
+### Detailed guidance: `https://review.learn.microsoft.com/help/learn/id-guidance-knowledge-check?branch=main`
+###########################################################################
+quiz:
+  questions:
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+  - content: "TODO"
+    choices:
+    - content: "TODO"
+      isCorrect: true
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"
+    - content: "TODO"
+      isCorrect: false
+      explanation: "TODO"

--- a/module-type-definitions/standard-concept-based.json
+++ b/module-type-definitions/standard-concept-based.json
@@ -1,0 +1,61 @@
+{
+  "moduleType": "standard-concept-based",
+  "moduleTemplatePath": "..\\content-templates\\standard-concept-based\\index.yml",
+  "moduleTitleTemplate": "{concepts} concepts",
+  "units":[
+    {
+      "type": "introduction",
+      "moduleUnitTemplatePath": "..\\content-templates\\default-units\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\standard-concept-based\\introduction.md",
+      "scaffoldFilename": "introduction",
+      "unitTitleTemplate": "Introduction"
+    },
+    {
+      "type": "knowledge-check",
+      "moduleUnitTemplatePath": "..\\content-templates\\standard-concept-based\\pretest.yml",
+      "scaffoldFilename": "pretest",
+      "unitTitleTemplate": "Pretest"
+    },
+    {
+      "type": "learning-content",
+      "moduleUnitTemplatePath": "..\\content-templates\\standard-concept-based\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\standard-concept-based\\learning-content.md",
+      "scaffoldFilename": "{first-concept}",
+      "unitTitleTemplate": "{first-concept}"
+    },
+    {
+      "type": "learning-content",
+      "moduleUnitTemplatePath": "..\\content-templates\\standard-concept-based\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\standard-concept-based\\learning-content.md",
+      "scaffoldFilename": "{second-concept}",
+      "unitTitleTemplate": "{second-concept}"
+    },
+    {
+      "type": "learning-content",
+      "moduleUnitTemplatePath": "..\\content-templates\\standard-concept-based\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\standard-concept-based\\learning-content.md",
+      "scaffoldFilename": "{last-concept}",
+      "unitTitleTemplate": "{last-concept}"
+    },
+    {
+      "type": "exercise",
+      "moduleUnitTemplatePath": "..\\content-templates\\default-units\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\standard-concept-based\\exercise.md",
+      "scaffoldFilename": "exercise",
+      "unitTitleTemplate": "Enter exercise title"
+    },
+    {
+      "type": "knowledge-check",
+      "moduleUnitTemplatePath": "..\\content-templates\\default-units\\knowledge-check-unit.yml",
+      "scaffoldFilename": "knowledge-check",
+      "unitTitleTemplate": "Knowledge check"
+    },
+    {
+      "type": "summary",
+      "moduleUnitTemplatePath": "..\\content-templates\\default-units\\unit.yml",
+      "contentTemplatePath": "..\\content-templates\\default-units\\summary.md",
+      "scaffoldFilename": "summary",
+      "unitTitleTemplate": "Summary"
+    }
+  ]
+}


### PR DESCRIPTION
This PR is for [Task 212538: New pattern: Concept module](https://dev.azure.com/msft-skilling/Skilling/_workitems/edit/212538).

It creates template files for a new training pattern, [Standard concept-based](https://review.learn.microsoft.com/en-us/help/patterns/level4/standard-concept-based-template?branch=main).

This PR also makes minor changes to existing files in the repo's *content-templates/default-units* folder:

- Changes the `ms.topic` value of unit YAML files to `unit` to follow the guidance in [Sample unit YAML file](https://review.learn.microsoft.com/en-us/help/learn/create-scaffold-manual?branch=main#sample-unit-yaml-file-content-only-unit)
- Removes the discussion of `ms.prod`
- Updates a few broken links